### PR TITLE
added a new import for the angle_between_vectors function 

### DIFF
--- a/manimlib/mobject/mobject.py
+++ b/manimlib/mobject/mobject.py
@@ -21,6 +21,7 @@ from manimlib.utils.simple_functions import get_parameters
 from manimlib.utils.space_ops import angle_of_vector
 from manimlib.utils.space_ops import get_norm
 from manimlib.utils.space_ops import rotation_matrix
+from manimlib.utils.space_ops import angle_between_vectors
 
 
 # TODO: Explain array_attrs


### PR DESCRIPTION
just needed to add a new import in the mobject.py file to be able to use rotate_to_match_vector otherwise the function looks clean and simple

**Please ensure that your pull request works with the latest version of manim.**
You should also include:

1. The motivation for making this change (or link the relevant issues)
to be able to use the rotate_to_match_vector

2. How you tested the new behavior (e.g. a minimal working example, before/after
screenshots, gifs, commands, etc.) 
Tried using the function but needed an import for it to work
